### PR TITLE
Faster fmod and process signed float

### DIFF
--- a/src/fmod.c
+++ b/src/fmod.c
@@ -1,15 +1,12 @@
 #include <math.h>
 
 double fmod(double x, double div) {
-	//if div == nan return x directly
-	if (div != div) {
+	//if div or x is nan,return x directly
+	if (div != div || x != x) {
 		return x;
 	}
 	if (div == 0) {
 		return 0.0 / 0.0;
 	}
-	while (x > div) {
-		x -= div;
-	}
-	return x;
+	return x - (int) (x / div) * div;
 }


### PR DESCRIPTION
I fixed the problem of error handling with fmod last time.
However,I test it with 5 test cases on [http://en.cppreference.com/w/c/numeric/math/fmod](url),only one passed.It failed four.
The problem happened when x or div is a negative number.
I fixed it on a easy way,just by a formula so it can also run faster than before. 
What's more,I added another error handling that I forgot last time.